### PR TITLE
Fix lost precision in getUsdCentValue()

### DIFF
--- a/contracts/OmmerIco.sol
+++ b/contracts/OmmerIco.sol
@@ -163,7 +163,7 @@ contract OmmerIco is EthUsdPrice, Pausable {
      * NOTE: there's no rounding!
      */
     function getUsdCentValue(uint256 _wei) public view returns (uint256) {
-        return (_wei * 100 / 1 ether * ethInCents / 100);
+        return (_wei * ethInCents) / 1 ether;
     }
 
     function getRemainingTokensForSale() public view returns (uint256) {


### PR DESCRIPTION
Consider this situation:
_wei = 999999999999999999 (1 ether - 1 wei)
erhInCents = 100000 (1000 usd)

Previous result: 99000 (990 usd)
New result: 99999 (999.99 usd)